### PR TITLE
Kubernetes controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,34 @@
           - name: AD_SERVICE_ADDR
             value: "adservice:9555"
 	POD frontend находится в статусе running.
+
+# ДЗ 2
+1) Установил go, kind
+2) Создал ветку kubernetes-controllers
+3) Создал файл kind-config.yaml
+4) Запустил создание кластера
+kind create cluster --config kind-config.yaml
+5) Создал манифест frontend-replicaset.yaml
+Необходимо добавить selector
+spec.selector.matchLabels.app: frontend
+6) Изменил количество реплик
+kubectl scale replicaset frontend --replicas=3
+7) После ручного удаления POD-ов, PODs восстановились
+8) Применил снова манифест frontend-replicaset.yaml, количество реплик уменьшилось
+9) В манифесте поменял количество реплик на 3
+10) На DockerHub выложил версию образа с новым тегом ssky525/otus:frontend.v0.0.2
+11) Проверил образ, который указан в ReplicaSet (ssky525/otus:frontend.v0.0.2) и образ из которого сейчас запущены поды (ssky525/otus:frontend).
+12) ReplicaSet следит, чтобы количество подов соответствовало заданому количеству, при этом не проверяет соответствие запущенных подов шаблону.
+13) Собрал образ paymentservice. Навесил теги v0.0.1 и v0.0.2
+14) Написал манифест paymentservice-replicaset.yaml, который создает 3 реплики из образа ssky525/otus:frontend.v0.0.1
+15) Собрал образ paymentservice с двумя тегам:v0.0.1 и v0.0.2. Залил образы на dockerhub: ssky525/paymentservice:v0.0.1 и ssky525/paymentservice:v0.0.2
+16) Написал манифест paymentservice-replicaset.yaml с тремя репликами, разворачивающими из образа версии v0.0.1.
+17) Написал deployment манифест paymentservice-deployment.yaml с тремя репликами, разворачивающими из образа версии v0.0.1.
+18) Обновил deployment манифест paymentservice-deployment.yaml на версию v0.0.2. Создались новые поды с версией образа v0.0.2. Создано две ReplicaSet: Одна управляет тремя репликами pod с образом v0.0.2, другая реплика управляет нулем реплик pod с версией v0.0.1.
+19) Сделал откат deployment на версию 1
+20) Написал paymentservice-deployment-bg.yaml со стратегией обновления blue\green: maxSurge: 3 maxUnavailable: 0
+21) Написал paymentservice-deployment-reverse.yaml со стратегией обновления Reverse Rolling Update: maxSurge: 0 maxUnavailable: 1
+22) Создал манифест frontend-deployment.yaml из которого можно развернуть три реплики pod с тегом образа v0.0.1. Добавил описание readnessProbe.
+23) Создал манифест node-exporter-daemonset.yaml для развертывания DaemonSet с Node Exporter. Выполнил kubectl port-forward node-exporter-xqr56 9100:9100. curl localhost:9100/metrics отдает метрики. Для того, чтобы pod управляемый DaemonSet развернулся на master ноде, нужно добавить 
+      tolerations:
+      - operator: Exists

--- a/kubernetes-controllers/frontend-deployment.yaml
+++ b/kubernetes-controllers/frontend-deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+      - name: server
+        image: ssky525/frontend:v0.0.2
+        readinessProbe:
+          initialDelaySeconds: 10
+          httpGet:
+            path: "/_healthz"
+            port: 8080
+            httpHeaders:
+            - name: "Cookie"
+              value: "shop_session-id=x-readiness-probe"
+        env:
+        - name: PORT
+          value: "8080"
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"

--- a/kubernetes-controllers/frontend-replicaset.yaml
+++ b/kubernetes-controllers/frontend-replicaset.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+      - name: server
+        image: ssky525/otus:frontend.v0.0.2
+        env:
+        - name: PORT
+          value: "8080"
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"

--- a/kubernetes-controllers/kind-config.yaml
+++ b/kubernetes-controllers/kind-config.yaml
@@ -1,0 +1,7 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: worker
+- role: worker
+- role: worker

--- a/kubernetes-controllers/node-exporter-daemonset.yaml
+++ b/kubernetes-controllers/node-exporter-daemonset.yaml
@@ -1,0 +1,92 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app.kubernetes.io/name: node-exporter
+    app.kubernetes.io/version: v0.18.1
+  name: node-exporter
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: node-exporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: node-exporter
+        app.kubernetes.io/version: v0.18.1
+    spec:
+      containers:
+      - args:
+        - --web.listen-address=127.0.0.1:9100
+        - --path.procfs=/host/proc
+        - --path.sysfs=/host/sys
+        - --path.rootfs=/host/root
+        - --no-collector.wifi
+        - --no-collector.hwmon
+        - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)
+        image: quay.io/prometheus/node-exporter:v0.18.1
+        name: node-exporter
+        resources:
+          limits:
+            cpu: 250m
+            memory: 180Mi
+          requests:
+            cpu: 102m
+            memory: 180Mi
+        volumeMounts:
+        - mountPath: /host/proc
+          name: proc
+          readOnly: false
+        - mountPath: /host/sys
+          name: sys
+          readOnly: false
+        - mountPath: /host/root
+          mountPropagation: HostToContainer
+          name: root
+          readOnly: true
+      - args:
+        - --logtostderr
+        - --secure-listen-address=[$(IP)]:9100
+        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+        - --upstream=http://127.0.0.1:9100/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay.io/coreos/kube-rbac-proxy:v0.4.1
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9100
+          hostPort: 9100
+          name: https
+        resources:
+          limits:
+            cpu: 20m
+            memory: 40Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+      tolerations:
+      - operator: Exists
+      volumes:
+      - hostPath:
+          path: /proc
+        name: proc
+      - hostPath:
+          path: /sys
+        name: sys
+      - hostPath:
+          path: /
+        name: root
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%
+

--- a/kubernetes-controllers/paymentservice-deployment-bg.yaml
+++ b/kubernetes-controllers/paymentservice-deployment-bg.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+        maxSurge: 3
+        maxUnavailable: 0
+  replicas: 3
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: server
+        image: ssky525/paymentservice:v0.0.2
+        env:
+        - name: PORT
+          value: "8080"
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"

--- a/kubernetes-controllers/paymentservice-deployment-reverse.yaml
+++ b/kubernetes-controllers/paymentservice-deployment-reverse.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+        maxSurge: 0
+        maxUnavailable: 1
+  replicas: 3
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: server
+        image: ssky525/paymentservice:v0.0.2
+        env:
+        - name: PORT
+          value: "8080"
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"

--- a/kubernetes-controllers/paymentservice-deployment.yaml
+++ b/kubernetes-controllers/paymentservice-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: server
+        image: ssky525/paymentservice:v0.0.2
+        env:
+        - name: PORT
+          value: "8080"
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"

--- a/kubernetes-controllers/paymentservice-replicaset.yaml
+++ b/kubernetes-controllers/paymentservice-replicaset.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: server
+        image: ssky525/paymentservice:v0.0.1
+        env:
+        - name: PORT
+          value: "8080"
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"


### PR DESCRIPTION
# Выполнено ДЗ №

 - [ ] Основное ДЗ
 - [ ] Задание со *

## В процессе сделано:
1) Установил go, kind
2) Создал ветку kubernetes-controllers
3) Создал файл kind-config.yaml
4) Запустил создание кластера
kind create cluster --config kind-config.yaml
5) Создал манифест frontend-replicaset.yaml
Необходимо добавить selector
spec.selector.matchLabels.app: frontend
6) Изменил количество реплик
kubectl scale replicaset frontend --replicas=3
7) После ручного удаления POD-ов, PODs восстановились
8) Применил снова манифест frontend-replicaset.yaml, количество реплик уменьшилось
9) В манифесте поменял количество реплик на 3
10) На DockerHub выложил версию образа с новым тегом ssky525/otus:frontend.v0.0.2
11) Проверил образ, который указан в ReplicaSet (ssky525/otus:frontend.v0.0.2) и образ из которого сейчас запущены поды (ssky525/otus:frontend).
12) ReplicaSet следит, чтобы количество подов соответствовало заданому количеству, при этом не проверяет соответствие запущенных подов шаблону.
13) Собрал образ paymentservice. Навесил теги v0.0.1 и v0.0.2
14) Написал манифест paymentservice-replicaset.yaml, который создает 3 реплики из образа ssky525/otus:frontend.v0.0.1
15) Собрал образ paymentservice с двумя тегам:v0.0.1 и v0.0.2. Залил образы на dockerhub: ssky525/paymentservice:v0.0.1 и ssky525/paymentservice:v0.0.2
16) Написал манифест paymentservice-replicaset.yaml с тремя репликами, разворачивающими из образа версии v0.0.1.
17) Написал deployment манифест paymentservice-deployment.yaml с тремя репликами, разворачивающими из образа версии v0.0.1.
18) Обновил deployment манифест paymentservice-deployment.yaml на версию v0.0.2. Создались новые поды с версией образа v0.0.2. Создано две ReplicaSet: Одна управляет тремя репликами pod с образом v0.0.2, другая реплика управляет нулем реплик pod с версией v0.0.1.
19) Сделал откат deployment на версию 1
20) Написал paymentservice-deployment-bg.yaml со стратегией обновления blue\green: maxSurge: 3 maxUnavailable: 0
21) Написал paymentservice-deployment-reverse.yaml со стратегией обновления Reverse Rolling Update: maxSurge: 0 maxUnavailable: 1
22) Создал манифест frontend-deployment.yaml из которого можно развернуть три реплики pod с тегом образа v0.0.1. Добавил описание readnessProbe.
23) Создал манифест node-exporter-daemonset.yaml для развертывания DaemonSet с Node Exporter. Выполнил kubectl port-forward node-exporter-xqr56 9100:9100. curl localhost:9100/metrics отдает метрики. Для того, чтобы pod управляемый DaemonSet развернулся на master ноде, нужно добавить 
      tolerations:
      - operator: Exists

## Как запустить проект:
 - kubectl port-forward node-exporter-xqr56 9100:9100

## Как проверить работоспособность:
 - curl localhost:9100/metrics

## PR checklist:
 - [ ] Выставлен label с темой домашнего задания
